### PR TITLE
Few improvements of Ban and Kick commands

### DIFF
--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -6,7 +6,7 @@ export default class BanCommand implements Command {
     info = {
         names: ['ban'],
         description: 'Bannin crazy',
-        usage: '&ban (ping) { reason }',
+        usage: '&ban (ping | userID) { reason }',
         category: 'admin'
     };
 
@@ -15,10 +15,10 @@ export default class BanCommand implements Command {
             return message.reply(messages.noPermission);
         if(!args.length)
             return message.reply(`${messages.use} \`${this.info.usage}\``);
-        if(!args[0].match(/<@[0-9]{17,}>/))
+        if(!message.mentions.members.first() && !message.guild.member(args[0]))
             return message.reply(`${messages.use} \`${this.info.usage}\``);
 
-        let member: GuildMember = message.guild.member(args[0].substring(2, 20) || message.guild.member(args[0].substring(2, 19)));
+        let member: GuildMember = message.mentions.members.first() || message.guild.member(args[0]);
         if(!member)
             return message.reply(messages.couldNotFind);
         if(!member.bannable)

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -6,19 +6,19 @@ export default class BanCommand implements Command {
     info = {
         names: ['ban'],
         description: 'Bannin crazy',
-        usage: '&ban (ping | name..)',
+        usage: '&ban (ping) { reason }',
         category: 'admin'
     };
 
     run(message: Message, args: string[], messages: Messages): any {
         if(!message.member.hasPermission('BAN_MEMBERS'))
             return message.reply(messages.noPermission);
-        if(args.length == 0)
+        if(!args.length)
             return message.reply(`${messages.use} \`${this.info.usage}\``);
-        if(!args[0].match(/<@[0-9]{18}>/))
+        if(!args[0].match(/<@[0-9]{17,}>/))
             return message.reply(`${messages.use} \`${this.info.usage}\``);
 
-        let member: GuildMember = message.guild.member(args.shift().substring(2, 20));
+        let member: GuildMember = message.guild.member(args[0].substring(2, 20) || message.guild.member(args[0].substring(2, 19)));
         if(!member)
             return message.reply(messages.couldNotFind);
         if(!member.bannable)

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -24,11 +24,9 @@ export default class BanCommand implements Command {
         if(!member.bannable)
             return message.reply(messages.couldNotBan);
 
-        member.user.send(
-            messages.youWereBanned.replace('{}', message.guild.name)
-            + ((args.length > 0) ? ': ' + args.join(' ') : '')
-        ).then((): void => {
-            member.ban();
+        member.user.send(messages.youWereBanned.replace('{}', message.guild.name) + ((args.length) ? `: ${args.join(' ')}` : ''))
+        .then((): void => {
+            member.ban((args.length) ? `${args.join(' ')} | responsible moderator: ${message.author.tag}` : `No reason provided. | responsible moderator: ${message.author.tag}`);
             message.reply(messages.banned.replace('{}', member.user.username));
         });
     }

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -6,7 +6,7 @@ export default class KickCommand implements Command {
     info = {
         names: ['kick'],
         description: 'Kicks someone',
-        usage: '&kick (ping) { reason }',
+        usage: '&kick (ping | userID) { reason }',
         category: 'admin'
     };
 
@@ -15,10 +15,10 @@ export default class KickCommand implements Command {
             return message.reply(messages.noPermission);
         if(!args.length)
             return message.reply(`${messages.use} \`${this.info.usage}\``);
-        if(!args[0].match(/<@[0-9]{17,}>/))
+        if(!message.mentions.members.first() && !message.guild.member(args[0]))
             return message.reply(`${messages.use} \`${this.info.usage}\``);
 
-        let member: GuildMember = message.guild.member(args[0].substring(2, 20)) || message.guild.member(args[0].substring(2, 19));
+        let member: GuildMember = message.mentions.members.first() || message.guild.member(args[0]);
         if(!member)
             return message.reply(messages.couldNotFind);
         if(!member.kickable)

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -24,12 +24,9 @@ export default class KickCommand implements Command {
         if(!member.kickable)
             return message.reply(messages.couldNotKick);
 
-        member.kick().then((member: GuildMember): void => {
-            member.user.send(
-                messages.youWereKicked.replace('{}', message.guild.name)
-                + (args.length > 0) ? ': ' + args.join(' ') : ''
-            );
-
+        member.user.send(messages.youWereKicked.replace('{}', message.guild.name) + ((args.length) ? `: ${args.join(' ')}` : ''))
+        .then((): void => {
+            member.kick((args.length) ? `${args.join(' ')} | responsible moderator: ${message.author.tag}` : `No reason provided. | responsible moderator: ${message.author.tag}`);
             message.reply(messages.kicked.replace('{}', member.user.username));
         });
     }

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -13,12 +13,12 @@ export default class KickCommand implements Command {
     run(message: Message, args: string[], messages: Messages): any {
         if(!message.member.hasPermission('KICK_MEMBERS'))
             return message.reply(messages.noPermission);
-        if(args.length == 0)
+        if(!args.length)
             return message.reply(`${messages.use} \`${this.info.usage}\``);
-        if(!args[0].match(/<@[0-9]{18}>/))
+        if(!args[0].match(/<@[0-9]{17,}>/))
             return message.reply(`${messages.use} \`${this.info.usage}\``);
 
-        let member: GuildMember = message.guild.member(args.shift().substring(2, 20));
+        let member: GuildMember = message.guild.member(args[0].substring(2, 20)) || message.guild.member(args[0].substring(2, 19));
         if(!member)
             return message.reply(messages.couldNotFind);
         if(!member.kickable)


### PR DESCRIPTION
I was browsing your bot repo, stumbled across those two commands and thought of few ways to improve those.

First of all, regexes you use, are good but not quite exact and those might not work in some cases. Small group of Discord users have their IDs only 17-number long and that means, you can't ban/kick those with regexes you had. That's the first commit

Next (second commit), using user IDs to ban them seems to be a better idea - many moderation channels, are not visible to regular users, thus, you just can't mention them in there, so executing moderator actions with IDs is pretty handy in those cases. Also, there's a better option for checking if member was mentioned - all message mentions are stored inside `message` object, so it's more safe.

Two last things. The action reason is being send to the user, but it isn't logged, while banning. It's useful to have that piece of information in logs for further reference. You can obviously do that by parsing a ban/kick reason as an argument to those functions. I also reduced few newlines near the end of each file, so the code looks more simple.

Let me know if something is unclear here, so I can explain that further. I'm not really a TypeScript developer, but guess that's a reasonable small improvement for izel that most bots support ;p